### PR TITLE
Use mount points

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,11 @@
 			"resolved": "https://registry.npmjs.org/@abcnews/err/-/err-1.0.3.tgz",
 			"integrity": "sha512-f5092lUTn6dJt1dODEibLZXfqF86zIZQXSt72k1ygsGpTlewDOz8y9ICBEro8Ea13S1qWgtscfh7Q3b1gWyoyw=="
 		},
+		"@abcnews/mount-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@abcnews/mount-utils/-/mount-utils-2.0.0.tgz",
+			"integrity": "sha512-oxN80eYE+RKURbseUzv5nDzRWuR2O+Vv0pfi9cEwztSUTpPIhCwKxRZc5IH4sulZKRQY+8pVZ3MMTT6Plw9jxw=="
+		},
 		"@abcnews/url2cmid": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@abcnews/url2cmid/-/url2cmid-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,11 @@
 				}
 			}
 		},
+		"@abcnews/alternating-case-to-object": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@abcnews/alternating-case-to-object/-/alternating-case-to-object-2.0.1.tgz",
+			"integrity": "sha512-wI1q+IhC+A9kBTBQ7dWtWXjYfhpc9BoPOMgGME04x7Gw73yZs3Oi8D62mDW3QOg7MpspwNe/vFMyIL9jx606sA=="
+		},
 		"@abcnews/aunty": {
 			"version": "11.1.1",
 			"resolved": "https://registry.npmjs.org/@abcnews/aunty/-/aunty-11.1.1.tgz",
@@ -118,6 +123,11 @@
 					"dev": true
 				}
 			}
+		},
+		"@abcnews/env-utils": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@abcnews/env-utils/-/env-utils-1.2.0.tgz",
+			"integrity": "sha512-p9yUWZchQhJVPGfueyNpg76B5mYjAZtaP2IZZEuUJ7w1WSxfDPzmOIdE7+lJqkHbaKuaVW13j/hNruibefHrlw=="
 		},
 		"@abcnews/err": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@abcnews/alternating-case-to-object": "^2.0.0",
 		"@abcnews/env-utils": "^1.0.1",
 		"@abcnews/err": "^1.0.3",
+		"@abcnews/mount-utils": "^2.0.0",
 		"@abcnews/url2cmid": "^1.0.1",
 		"classnames": "^2.2.6",
 		"es6-object-assign": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
 		"svg-loader": "0.0.2"
 	},
 	"dependencies": {
+		"@abcnews/alternating-case-to-object": "^2.0.0",
+		"@abcnews/env-utils": "^1.0.1",
 		"@abcnews/err": "^1.0.3",
 		"@abcnews/url2cmid": "^1.0.1",
 		"classnames": "^2.2.6",

--- a/public/index.html
+++ b/public/index.html
@@ -12,11 +12,13 @@
   }
 </style>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="index.js"></script>
 
 <h1>Example Quiz</h1>
-<div data-quiz="custom-888"></div>
+<a name="quizID12322746"></a>
 <h1>Example Survey</h1>
-<div data-quiz="9714080"></div>
-<script src="index.js"></script>
-<a name="quizID9714080" />
+<a name="quizID9714080"></a>
+<h1>Broken quiz</h1>
+<p>This quiz has only one question (which is fine), but that question has no answers. It should still render what it can.</p>
+<a name="quizID12320116"></a>
 <!-- http://www.abc.net.au/dat/news/interactives/quizzes/quiz-1503883941.0942.json -->

--- a/public/index.html
+++ b/public/index.html
@@ -18,5 +18,5 @@
 <h1>Example Survey</h1>
 <div data-quiz="9714080"></div>
 <script src="index.js"></script>
-
+<a name="quizID9714080" />
 <!-- http://www.abc.net.au/dat/news/interactives/quizzes/quiz-1503883941.0942.json -->

--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,15 @@ const url2cmid = require('@abcnews/url2cmid');
 const fastclick = require('fastclick');
 const a2o = require('@abcnews/alternating-case-to-object');
 const {whenDOMReady} = require('@abcnews/env-utils')
+const {selectMounts, getMountValue} = require('@abcnews/mount-utils')
 const App = require('./components');
 
 // Polyfills
 require('es6-object-assign/auto'); // Object.assign for IE
 
 function init() {
-  [...document.querySelectorAll('a[name^=quiz],a[id^=quiz]')].forEach(anchor => {
-    const props = a2o(anchor.getAttribute("id") || anchor.getAttribute("name"));
-    const mount = document.createElement("div");
-    anchor.parentElement.insertBefore(mount, anchor);
-    anchor.parentElement.removeChild(anchor);
+  selectMounts('quiz').forEach(mount => {
+    const props = a2o(getMountValue(mount));
     fastclick.attach(mount);
     render(<App id={(props.id || url2cmid(window.location.href)).toString()} />, mount);
   })

--- a/src/index.js
+++ b/src/index.js
@@ -1,31 +1,30 @@
 const { h, render } = require('preact');
 const url2cmid = require('@abcnews/url2cmid');
-const instances = document.querySelectorAll('[data-quiz]');
-const meta = document.querySelector('meta[name=quiz]');
-const quizzes = meta ? meta.getAttribute('content').split(',') : [];
 const fastclick = require('fastclick');
+const a2o = require('@abcnews/alternating-case-to-object');
+const domready = fn => /in/.test(document.readyState) ? setTimeout(() => domready(fn), 9) : fn();
+const App = require('./components');
 
 // Polyfills
 require('es6-object-assign/auto'); // Object.assign for IE
 
-function init([idx, root]) {
-  const App = require('./components');
-  const id =
-    root.dataset.quiz || quizzes[idx] || url2cmid(window.location.href);
-  fastclick.attach(root);
-  render(<App id={id} />, root, root.firstChild);
+function init() {
+  [...document.querySelectorAll('a[name^=quiz],a[id^=quiz]')].forEach(anchor => {
+    const props = a2o(anchor.getAttribute("id") || anchor.getAttribute("name"));
+    const mount = document.createElement("div");
+    anchor.parentElement.insertBefore(mount, anchor);
+    anchor.parentElement.removeChild(anchor);
+    fastclick.attach(mount);
+    render(<App id={(props.id || url2cmid(window.location.href)).toString()} />, mount);
+  })
 }
 
-for (let i = 0; i < instances.length; ++i) {
-  init([i, instances[i]]);
-}
+domready(init);
 
 if (module.hot) {
   module.hot.accept('./components', () => {
     try {
-      for (let i = 0; i < instances.length; ++i) {
-        init([i, instances[i]]);
-      }
+      domready(init);
     } catch (err) {
       const ErrorBox = require('./components/error-box');
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { h, render } = require('preact');
 const url2cmid = require('@abcnews/url2cmid');
 const fastclick = require('fastclick');
 const a2o = require('@abcnews/alternating-case-to-object');
-const domready = fn => /in/.test(document.readyState) ? setTimeout(() => domready(fn), 9) : fn();
+const {whenDOMReady} = require('@abcnews/env-utils')
 const App = require('./components');
 
 // Polyfills
@@ -19,12 +19,12 @@ function init() {
   })
 }
 
-domready(init);
+whenDOMReady.then(init);
 
 if (module.hot) {
   module.hot.accept('./components', () => {
     try {
-      domready(init);
+      whenDOMReady.then(init);
     } catch (err) {
       const ErrorBox = require('./components/error-box');
 


### PR DESCRIPTION
This represents a breaking change.

It changes the embed method to support PL outputs without hardcoding the JS version for the quiz viewer in PL.

Instead of using HTML Fragments to embed, it uses named anchor links as mount points.

Replaces #50 